### PR TITLE
Fix `SplitArgs` to correctly parse non-ASCII input.

### DIFF
--- a/src/str_index.rs
+++ b/src/str_index.rs
@@ -1,0 +1,67 @@
+use core::ops::Index;
+
+/// A safe index into [`str`] that works over codepoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StrIndex(usize);
+
+impl StrIndex {
+    /// Create a new [`StrIndex`] that points at the start of a [`str`].
+    pub fn zero() -> Self {
+        Self(0)
+    }
+
+    /// Get the byte index.
+    ///
+    /// This can be used to safely index into a [`str`].
+    pub fn byte_index(self) -> usize {
+        self.0
+    }
+
+    /// Increment the index with `c`.
+    ///
+    /// This method ensures that the index is always pointing at a [`char`]
+    /// boundary.
+    pub fn advance(&mut self, c: char) {
+        self.0 += c.len_utf8();
+    }
+
+    /// Get the [`char`] from `s`.
+    pub fn get(self, s: &str) -> Option<char> {
+        let s = s.get(self.0..)?;
+        s.chars().next()
+    }
+}
+
+/// A [`Range`] but for [`str`].
+///
+/// Semantics are equivalent to [`Range`].
+///
+/// [`Range`]: core::ops::Range
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StrRange {
+    pub start: StrIndex,
+    pub end: StrIndex,
+}
+
+impl StrRange {
+    /// Get the [`str`] slice of this range from `s`.
+    ///
+    /// Returns [`None`] is the range points outside `s`.
+    pub fn get(self, s: &str) -> Option<&str> {
+        let start = self.start.byte_index();
+        let end = self.end.byte_index();
+
+        s.get(start..end)
+    }
+}
+
+impl Index<StrRange> for str {
+    type Output = str;
+
+    fn index(&self, index: StrRange) -> &Self::Output {
+        let start = index.start.byte_index();
+        let end = index.end.byte_index();
+
+        &self[start..end]
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,7 +12,9 @@ use miniarg::{parse, ParseError};
 fn basic() {
     let cmdline = "executable";
     assert_eq!(
-        parse::<&str>(&cmdline, &[]).collect::<Result<Vec<(_, _)>, _>>().unwrap(),
+        parse::<&str>(&cmdline, &[])
+            .collect::<Result<Vec<(_, _)>, _>>()
+            .unwrap(),
         Vec::new()
     );
 }
@@ -22,7 +24,9 @@ fn basic() {
 fn key_value() {
     let cmdline = "executable -key value";
     assert_eq!(
-        parse(&cmdline, &["key"]).collect::<Result<Vec<_>, _>>().unwrap(),
+        parse(&cmdline, &["key"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap(),
         vec![(&"key", "value")]
     );
 }
@@ -32,7 +36,9 @@ fn key_value() {
 fn two_key_value() {
     let cmdline = "executable -key1 value1 -key2 value2";
     assert_eq!(
-        parse(&cmdline, &["key1", "key2"]).collect::<Result<Vec<_>, _>>().unwrap(),
+        parse(&cmdline, &["key1", "key2"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap(),
         vec![(&"key1", "value1"), (&"key2", "value2")]
     );
 }
@@ -42,7 +48,9 @@ fn two_key_value() {
 fn key_two_value() {
     let cmdline = "executable -key value1 -key value2";
     assert_eq!(
-        parse(&cmdline, &["key", "key"]).collect::<Result<Vec<_>, _>>().unwrap(),
+        parse(&cmdline, &["key", "key"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap(),
         vec![(&"key", "value1"), (&"key", "value2")]
     );
 }
@@ -53,7 +61,9 @@ fn key_two_value() {
 fn just_key() {
     let cmdline = "executable -key";
     assert_eq!(
-        parse(&cmdline, &["key"]).collect::<Result<Vec<_>, _>>().unwrap(),
+        parse(&cmdline, &["key"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap(),
         vec![(&"key", "")]
     );
 }
@@ -63,7 +73,9 @@ fn just_key() {
 fn invalid_key() {
     let cmdline = "executable -invalid";
     assert_eq!(
-        parse(&cmdline, &["key"]).collect::<Result<Vec<_>, _>>().unwrap_err(),
+        parse(&cmdline, &["key"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_err(),
         ParseError::UnknownKey("invalid")
     );
 }
@@ -73,7 +85,20 @@ fn invalid_key() {
 fn missing_key() {
     let cmdline = "executable value";
     assert_eq!(
-        parse(&cmdline, &["key"]).collect::<Result<Vec<_>, _>>().unwrap_err(),
+        parse(&cmdline, &["key"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_err(),
         ParseError::NotAKey("value")
+    );
+}
+
+#[test]
+fn non_ascii() {
+    let cmdline = "executable -value 🦀🎉";
+    assert_eq!(
+        parse(&cmdline, &["value"])
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap(),
+        vec![(&"value", "🦀🎉")]
     );
 }


### PR DESCRIPTION
This PR fixes #1.